### PR TITLE
Typo corrections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,4 +4,4 @@ You may use this code freely for noncommercial use.
 
 I can't imagine how this code would be useful for commercial use, but in the event that you would like to make money off of it, I would want a small cut so please email me so we can work something out.
 
-I think Altas has some cool new ideas and I hope that they are used in future languages, please credit Atlas if you use specific ideas or techniques pioneered in it.
+I think Atlas has some cool new ideas and I hope that they are used in future languages, please credit Atlas if you use specific ideas or techniques pioneered in it.

--- a/repl.rb
+++ b/repl.rb
@@ -109,7 +109,7 @@ def repl(input=nil)
     rescue Errno::EPIPE
       exit
     rescue => e
-      STDERR.puts "!!!This is an internal Altas error, please report the bug (via github issue or email name of this lang at golfscript.com)!!!\n\n"
+      STDERR.puts "!!!This is an internal Atlas error, please report the bug (via github issue or email name of this lang at golfscript.com)!!!\n\n"
       raise e
     end
   } # loop


### PR DESCRIPTION
"Altas" was replaced twice by "Atlas". One of them is particularly striking when an error is caused.